### PR TITLE
Ignore input key if it is not acceptable by the mask at the given position

### DIFF
--- a/projects/racoon/primeng/src/lib/prime-ng-calendar-mask/prime-ng-calendar-mask.ts
+++ b/projects/racoon/primeng/src/lib/prime-ng-calendar-mask/prime-ng-calendar-mask.ts
@@ -1,11 +1,10 @@
 import { AfterViewChecked, Directive, ElementRef, HostListener, Input, NgModule, OnDestroy, Renderer2 } from "@angular/core";
 import { Calendar, CalendarModule } from "primeng/primeng";
 import { Subscription } from "rxjs";
-import { MaskingBase } from "racoon-mask-base";
+import { MaskingBase } from "../../../../base/src/lib/masking-base/masking-base";
 
 @Directive({
-    selector: "p-calendar[rPCalendarMask]",
-
+    selector: "p-calendar[rPCalendarMask]"
 })
 export class PrimeNgCalendarMaskDirective extends MaskingBase implements AfterViewChecked, OnDestroy {
     private selectSubscriber: Subscription;


### PR DESCRIPTION
The behavior was a bit odd when the user entered such a character which was not suitable to the mask at the given position.
Repro steps for the original PrimeNG CalendarMask:
- set overwriteOnInsert to true
- use a proper date format or even the default
- first type a valid date
- edit entered value by typing alpha characters (the value should be get shorter and shorter)

If the overwriteOnInsert is set to false, or in case of Raw Racoon Mask the cursor "only" steps to the next position.