### PR TITLE
Reduce bundle size

### DIFF
--- a/projects/racoon/full/src/lib/prime-ng-calendar-mask/prime-ng-calendar-mask.ts
+++ b/projects/racoon/full/src/lib/prime-ng-calendar-mask/prime-ng-calendar-mask.ts
@@ -1,5 +1,5 @@
 import { AfterViewChecked, Directive, ElementRef, HostListener, Input, NgModule, OnDestroy, Renderer2 } from "@angular/core";
-import { Calendar, CalendarModule } from "primeng/primeng";
+import { Calendar, CalendarModule } from "primeng/calendar";
 import { MaskingBase } from "racoon-mask-base";
 import { Subscription } from "rxjs";
 

--- a/projects/racoon/primeng/src/lib/prime-ng-calendar-mask/prime-ng-calendar-mask.ts
+++ b/projects/racoon/primeng/src/lib/prime-ng-calendar-mask/prime-ng-calendar-mask.ts
@@ -1,5 +1,5 @@
 import { AfterViewChecked, Directive, ElementRef, HostListener, Input, NgModule, OnDestroy, Renderer2 } from "@angular/core";
-import { Calendar, CalendarModule } from "primeng/primeng";
+import { Calendar, CalendarModule } from "primeng/calendar";
 import { Subscription } from "rxjs";
 import { MaskingBase } from "../../../../base/src/lib/masking-base/masking-base";
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from "@angular/platform-browser";
 import { NgModule } from "@angular/core";
 
 import { AppComponent } from "./app.component";
-import { CalendarModule } from "primeng/primeng";
+import { CalendarModule } from "primeng/calendar";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { CrudeComponent } from "./raw/crude.component";
 import { PrimengComponent } from "./primeng/primeng.component";


### PR DESCRIPTION
This way of importing allows unused PrimeNG modules to be excluded from the bundle saving up about 1 MB in size. See primefaces/primeng#4412 and https://forum.primefaces.org/viewtopic.php?p=160826#p160826 for details.