### PR TITLE
Allow support for angular version 8

### DIFF
--- a/projects/racoon/base/package.json
+++ b/projects/racoon/base/package.json
@@ -2,8 +2,8 @@
     "name": "racoon-mask-base",
     "version": "1.1.9",
     "peerDependencies": {
-        "@angular/common": "^7.2.0",
-        "@angular/core": "^7.2.0"
+        "@angular/common": "^7.2.0 || ^8.0.0",
+        "@angular/core": "^7.2.0 || ^8.0.0"
     },
     "author": {
         "email": "shogogan@gmail.com",

--- a/projects/racoon/primeng/package.json
+++ b/projects/racoon/primeng/package.json
@@ -2,9 +2,9 @@
     "name": "racoon-mask-primeng",
     "version": "1.1.13",
     "peerDependencies": {
-        "@angular/common": "^7.2.0",
-        "@angular/core": "^7.2.0",
-        "primeng": "^7.0.5"
+        "@angular/common": "^7.2.0 || ^8.0.0",
+        "@angular/core": "^7.2.0 || ^8.0.0",
+        "primeng": "^7.0.5 || ^8.0.0"
     },
     "dependencies": {
         "racoon-mask-base": "1.1.9"


### PR DESCRIPTION
This allows the package `racon-mask-primeng` to be installed by users of Angular 8 without the following warnings:

```shell
npm WARN racoon-mask-base@1.1.9 requires a peer of @angular/common@^7.2.0 but none is installed. You must install peer dependencies yourself.
npm WARN racoon-mask-base@1.1.9 requires a peer of @angular/core@^7.2.0 but none is installed. You must install peer dependencies yourself.
npm WARN racoon-mask-primeng@1.1.14 requires a peer of @angular/common@^7.2.0 but none is installed. You must install peer dependencies yourself.
npm WARN racoon-mask-primeng@1.1.14 requires a peer of @angular/core@^7.2.0 but none is installed. You must install peer dependencies yourself.
npm WARN racoon-mask-primeng@1.1.14 requires a peer of primeng@^7.0.5 but none is installed. You must install peer dependencies yourself.
```